### PR TITLE
Make A sides go on the left

### DIFF
--- a/vimtabdiff.py
+++ b/vimtabdiff.py
@@ -87,7 +87,8 @@ def main() -> None:
                 and open(aPath, mode="rb").read() == open(bPath, mode="rb").read()
             ):
                 continue
-            print(f"tabedit {aPath} | vsp {bPath}", file=vimCmdFile)
+            # This puts aPath on the left
+            print(f"tabedit {bPath} | vsp {aPath}", file=vimCmdFile)
         cmds = f"""
         tabdo windo :1
         tabdo windo diffthis


### PR DESCRIPTION
Currently, `vimtabdiff.py leftdir rightdir` puts the leftdir on the right.

I think every other program would put it on the left.

If you prefer the current behavior, I can make this a command-line option.